### PR TITLE
Clamp overlay dimensions to terminal size

### DIFF
--- a/src/overlays/util.rs
+++ b/src/overlays/util.rs
@@ -6,10 +6,12 @@ use ratatui::{
     Frame,
 };
 
-pub const fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
-    let x = area.x + (area.width.saturating_sub(width)) / 2;
-    let y = area.y + (area.height.saturating_sub(height)) / 2;
-    Rect::new(x, y, width, height)
+pub fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w, h)
 }
 
 pub fn render_overlay_frame(frame: &mut Frame, area: Rect, title: &str, color: Color) -> Rect {


### PR DESCRIPTION
Fix crash when opening an overlay on a small terminal by clamping the requested width and height to the available area in `centered_rect()`.

The root cause was that `centered_rect()` used the requested overlay dimensions directly without clamping to the terminal size. On a terminal narrower than the overlay's fixed width, the created `Rect` extended beyond the buffer, causing ratatui to panic with:

> index outside of buffer: the area is Rect { x: 0, y: 0, width: 41, height: 31 } but index is (41, 11)

Closes #1