### PR TITLE
Capture notification errors and display in overlay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -74,7 +74,9 @@ impl App {
             if let Some(ref audio) = self.audio {
                 audio.play_notification();
             }
-            send_notification("Pomo-TUI", "Session completed!");
+            if let Some(err) = send_notification("Pomo-TUI", "Session completed!") {
+                self.error_message = Some(err);
+            }
         }
 
         self.timer_panel.next_animation_frame();


### PR DESCRIPTION
notify-send stderr was inherited by the TUI process, causing D-Bus errors to corrupt the terminal display when the notification service was unavailable.

Now stderr/stdout are captured and any errors are shown in the existing error overlay instead.

Closes #3