### PR TITLE
Create default task file when sync is requested without --tasks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -93,9 +93,10 @@ impl App {
 
     fn sync_tasks(&mut self) {
         if !self.task_manager.has_file_path() {
-            self.error_message =
-                Some("No task file provided. Use --tasks <file> to enable sync.".to_string());
-            return;
+            if let Err(e) = self.task_manager.create_default_file() {
+                self.error_message = Some(format!("Failed to create default task file: {e}"));
+                return;
+            }
         }
         match self.task_manager.compute_sync_items() {
             Ok(items) => {


### PR DESCRIPTION
## Summary

Fixes #9. When the user presses `s` to sync without providing a task file via `--tasks`, the app now automatically creates and uses `~/.cache/pomo-tui/tasks.md` instead of showing an error message.

## Changes

- Added `TaskManager::create_default_file()` method that:
  - Resolves the home directory using `HOME` or `USERPROFILE` environment variables
  - Creates `~/.cache/pomo-tui/` directory structure if it doesn't exist
  - Creates an empty `tasks.md` file if needed
  - Loads the file and merges any existing tasks into current state
- Updated `App::sync_tasks()` to call `create_default_file()` when no task file path exists
- Shows an error only if the file creation fails

## Test plan

- [x] Code compiles with no warnings (`cargo check`)
- [x] Manual test: Run `pomo-tui` without `--tasks`, add tasks, press `s` to sync
- [x] Verify `~/.cache/pomo-tui/tasks.md` is created with tasks
- [x] Test backward compatibility: Run with `--tasks custom.md` and verify sync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)